### PR TITLE
Logger Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ func application(application: UIApplication,
 }
 ```
 
+###Logging###
+
+By default, StyleKit will log any errors to the console. To customise the level of logging, you can pass a logLevel parameter as follows:
+
+```swift
+StyleKit(fileUrl: styleFile, logLevel: .Debug)?.apply()
+```
+
+The levels of logging are:
+
+* ```.Debug```
+* ```.Error``` (This is the default log level)
+* ```.Severe```
+* ```.None```
+
+
 ###How to install?
 
 ####Carthage

--- a/StyleKit.xcodeproj/project.pbxproj
+++ b/StyleKit.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		A1C5156B1D5A7DC00016BF1E /* success-style.json in Resources */ = {isa = PBXBuildFile; fileRef = A1C5156A1D5A7DC00016BF1E /* success-style.json */; };
 		A1C5156D1D5A7DE20016BF1E /* fail-style.json in Resources */ = {isa = PBXBuildFile; fileRef = A1C5156C1D5A7DE20016BF1E /* fail-style.json */; };
 		A1D8B1221D57C28A00355807 /* StyleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8B1211D57C28A00355807 /* StyleParser.swift */; };
-		A1E4676E1D59494C003B1AB2 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E4676D1D59494C003B1AB2 /* Logger.swift */; };
+		A1E4676E1D59494C003B1AB2 /* SKLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E4676D1D59494C003B1AB2 /* SKLogger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,7 +64,7 @@
 		A1C5156A1D5A7DC00016BF1E /* success-style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "success-style.json"; path = "Style/success-style.json"; sourceTree = "<group>"; };
 		A1C5156C1D5A7DE20016BF1E /* fail-style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "fail-style.json"; path = "Style/fail-style.json"; sourceTree = "<group>"; };
 		A1D8B1211D57C28A00355807 /* StyleParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyleParser.swift; sourceTree = "<group>"; };
-		A1E4676D1D59494C003B1AB2 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		A1E4676D1D59494C003B1AB2 /* SKLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,7 +156,7 @@
 				992723711D5B36D700B74CDD /* UIAppearance+Swift.h */,
 				992723721D5B36D700B74CDD /* UIAppearance+Swift.m */,
 				A104CE421D580D6A00626F2A /* ColorExtensions.swift */,
-				A1E4676D1D59494C003B1AB2 /* Logger.swift */,
+				A1E4676D1D59494C003B1AB2 /* SKLogger.swift */,
 				A104CE3E1D57E9D200626F2A /* StringExtensions.swift */,
 				059932D81D59E09D0085E522 /* SKTryCatch.h */,
 				059932DB1D59E0DF0085E522 /* SKTryCatch.m */,
@@ -279,7 +279,7 @@
 				996775991D5A2E8E005DA08A /* StyleParsable.swift in Sources */,
 				996775A11D5A38E8005DA08A /* ControlStateHelper.swift in Sources */,
 				A104CE3F1D57E9D200626F2A /* StringExtensions.swift in Sources */,
-				A1E4676E1D59494C003B1AB2 /* Logger.swift in Sources */,
+				A1E4676E1D59494C003B1AB2 /* SKLogger.swift in Sources */,
 				A10FD6BF1D55357400341EDD /* FileLoader.swift in Sources */,
 				059932DC1D59E0DF0085E522 /* SKTryCatch.m in Sources */,
 				A10FD6C81D556A9C00341EDD /* Stylist.swift in Sources */,

--- a/StyleKit/FileLoader.swift
+++ b/StyleKit/FileLoader.swift
@@ -16,7 +16,7 @@ class FileLoader {
                     return dictionary
                 }
             } catch {
-                XCGLogger.severe("Issue parsing StyleKit JSON file: \(self.jsonFile)" )
+                SKLogger.severe("Issue parsing StyleKit JSON file: \(self.jsonFile)" )
             }
         }
         return nil

--- a/StyleKit/Helpers/FontHelper.swift
+++ b/StyleKit/Helpers/FontHelper.swift
@@ -10,7 +10,7 @@ public struct FontHelper {
                 if let font = UIFont(name: fontString.first!, size: size) {
                     return font
                 } else {
-                    XCGLogger.error("Font \(font) not found, using system font.")
+                    SKLogger.error("Font \(font) not found, using system font.")
                     return UIFont.systemFontOfSize(size)
                 }
             } else {

--- a/StyleKit/StyleKit.swift
+++ b/StyleKit/StyleKit.swift
@@ -5,7 +5,7 @@ public class StyleKit {
     let stylist: Stylist
     
     public init?(fileUrl: NSURL, styleParser: StyleParsable? = nil, logLevel: LogLevel = .Error) {
-        let log = XCGLogger.defaultInstance()
+        let log = SKLogger.defaultInstance()
         log.setup(logLevel,
                   showLogIdentifier: false,
                   showFunctionName: true,

--- a/StyleKit/StyleKit.swift
+++ b/StyleKit/StyleKit.swift
@@ -4,13 +4,13 @@ public class StyleKit {
     
     let stylist: Stylist
     
-    public init?(fileUrl: NSURL, styleParser: StyleParsable? = nil, logLevel: LogLevel = .Error) {
+    public init?(fileUrl: NSURL, styleParser: StyleParsable? = nil, logLevel: SKLogLevel = .Error) {
         let log = SKLogger.defaultInstance()
         log.setup(logLevel,
                   showLogIdentifier: false,
                   showFunctionName: true,
                   showThreadName: true,
-                  showLogLevel: true,
+                  showSKLogLevel: true,
                   showFileNames: true,
                   showLineNumbers: true,
                   showDate: false)

--- a/StyleKit/Stylist.swift
+++ b/StyleKit/Stylist.swift
@@ -19,7 +19,7 @@ class Stylist {
         SKTryCatch.tryBlock( {
             self.validateAndApply(self.data)
         }, catchBlock: { exception in
-            XCGLogger.severe("There was an error while applying styles: \(exception)")
+            SKLogger.severe("There was an error while applying styles: \(exception)")
         }, finallyBlock: nil)
     }
     
@@ -40,7 +40,7 @@ class Stylist {
                 if let currentComponent = self.currentComponent {
                     applyStyle(key, object: value, currentComponent: currentComponent)
                 } else {
-                    XCGLogger.error("Style \(value) not applied on \(key) for \(self.currentComponent.debugDescription)")
+                    SKLogger.error("Style \(value) not applied on \(key) for \(self.currentComponent.debugDescription)")
                 }
                 
             }
@@ -49,10 +49,10 @@ class Stylist {
     
     private func selectCurrentComponent(name: String) -> Bool {
         
-        XCGLogger.debug("Switching to: \(name)")
+        SKLogger.debug("Switching to: \(name)")
         
         guard let currentComponent = NSClassFromString(name) else {
-            XCGLogger.debug("Component \(name) cannot be selected")
+            SKLogger.debug("Component \(name) cannot be selected")
             return false
         }
         self.currentComponent = currentComponent
@@ -71,7 +71,7 @@ class Stylist {
             state = nil
         }
         
-        XCGLogger.debug("Applying: \(selectorName) on level \(self.viewStack.count)")
+        SKLogger.debug("Applying: \(selectorName) on level \(self.viewStack.count)")
         if let styles = object as? Stylist.Style {
             var stylesToApply = Stylist.Style()
             for (style, value) in styles {

--- a/StyleKit/Utilities/Logger.swift
+++ b/StyleKit/Utilities/Logger.swift
@@ -1,6 +1,4 @@
-//
-//  XCGLogger.swift
-//  XCGLogger: https://github.com/DaveWoodCom/XCGLogger
+//  Inspired by XCGLogger: https://github.com/DaveWoodCom/XCGLogger
 //
 //  Created by Dave Wood on 2014-06-06.
 //  Copyright (c) 2014 Dave Wood, Cerebral Gardens.
@@ -43,18 +41,23 @@ public enum LogLevel: Int, Comparable, CustomStringConvertible {
     }
 }
 
+// Implement Comparable for LogLevel
+public func < (lhs:LogLevel, rhs:LogLevel) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
 
-// MARK: - XCGLogDetails
+
+// MARK: - SKLogDetails
 // - Data structure to hold all info about a log message, passed to log destination classes
-public struct XCGLogDetails {
-    public var logLevel: LogLevel
-    public var date: NSDate
-    public var logMessage: String
-    public var functionName: String
-    public var fileName: String
-    public var lineNumber: Int
+internal struct SKLogDetails {
+    var logLevel: LogLevel
+    var date: NSDate
+    var logMessage: String
+    var functionName: String
+    var fileName: String
+    var lineNumber: Int
 
-    public init(logLevel: LogLevel, date: NSDate, logMessage: String, functionName: StaticString, fileName: StaticString, lineNumber: Int) {
+    init(logLevel: LogLevel, date: NSDate, logMessage: String, functionName: StaticString, fileName: StaticString, lineNumber: Int) {
         self.logLevel = logLevel
         self.date = date
         self.logMessage = logMessage
@@ -64,36 +67,36 @@ public struct XCGLogDetails {
     }
 }
 
-// MARK: - XCGConsoleLogDestination
+// MARK: - SKConsoleLogDestination
 // - A standard log destination that outputs log details to the console
-public class XCGConsoleLogDestination: CustomDebugStringConvertible {
+internal class SKConsoleLogDestination: CustomDebugStringConvertible {
     // MARK: - Properties
-    public var owner: XCGLogger
-    public var outputLogLevel: LogLevel = .Debug
+    var owner: SKLogger
+    var outputLogLevel: LogLevel = .Debug
 
-    public var showFunctionName: Bool = true
-    public var showThreadName: Bool = false
-    public var showFileName: Bool = true
-    public var showLineNumber: Bool = true
-    public var showLogLevel: Bool = true
-    public var showDate: Bool = true
+    var showFunctionName: Bool = true
+    var showThreadName: Bool = false
+    var showFileName: Bool = true
+    var showLineNumber: Bool = true
+    var showLogLevel: Bool = true
+    var showDate: Bool = true
 
-    public var logQueue: dispatch_queue_t? = nil
+    var logQueue: dispatch_queue_t? = nil
 
     // MARK: - CustomDebugStringConvertible
-    public var debugDescription: String {
+    var debugDescription: String {
         get {
             return "\(extractClassName(self)): - LogLevel: \(outputLogLevel) showFunctionName: \(showFunctionName) showThreadName: \(showThreadName) showLogLevel: \(showLogLevel) showFileName: \(showFileName) showLineNumber: \(showLineNumber) showDate: \(showDate)"
         }
     }
 
     // MARK: - Life Cycle
-    public init(owner: XCGLogger) {
+    init(owner: SKLogger) {
         self.owner = owner
     }
 
     // MARK: - Methods to Process Log Details
-    public func processLogDetails(logDetails: XCGLogDetails) {
+    func processLogDetails(logDetails: SKLogDetails) {
         var extendedDetails: String = ""
 
         if showDate {
@@ -143,7 +146,7 @@ public class XCGConsoleLogDestination: CustomDebugStringConvertible {
         output(logDetails, text: extendedDetails + "> " + logDetails.logMessage)
     }
 
-    public func processInternalLogDetails(logDetails: XCGLogDetails) {
+    func processInternalLogDetails(logDetails: SKLogDetails) {
         var extendedDetails: String = ""
 
         if showDate {
@@ -165,12 +168,12 @@ public class XCGConsoleLogDestination: CustomDebugStringConvertible {
     }
 
     // MARK: - Misc methods
-    public func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
+    func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
         return logLevel >= self.outputLogLevel
     }
 
     // MARK: - Output
-    public func output(logDetails: XCGLogDetails, text: String) {
+    func output(logDetails: SKLogDetails, text: String) {
         let outputClosure = {
             print(text)
         }
@@ -184,34 +187,32 @@ public class XCGConsoleLogDestination: CustomDebugStringConvertible {
     }
 }
 
-// MARK: - XCGLogger
+// MARK: - SKLogger
 // - The main logging class
-public class XCGLogger: CustomDebugStringConvertible {
+internal class SKLogger: CustomDebugStringConvertible {
     // MARK: - Constants
-    public struct Constants {
-        public static let baseConsoleLogDestinationIdentifier = "com.cerebralgardens.xcglogger.logdestination.console"
-        public static let logQueueIdentifier = "OneFourSixBC.StyleKit.xcglogger.queue"
+    struct Constants {
+        static let logQueueIdentifier = "OneFourSixBC.StyleKit.xcglogger.queue"
     }
-    public typealias constants = Constants // Preserve backwards compatibility: Constants should be capitalized since it's a type
 
     // MARK: - Properties (Options)
-    public var outputLogLevel: LogLevel = .Debug {
+    var outputLogLevel: LogLevel = .Debug {
         didSet {
             logDestination.outputLogLevel = outputLogLevel
         }
     }
 
     // MARK: - Properties
-    public class var logQueue: dispatch_queue_t {
+    class var logQueue: dispatch_queue_t {
         struct Statics {
-            static var logQueue = dispatch_queue_create(XCGLogger.Constants.logQueueIdentifier, nil)
+            static var logQueue = dispatch_queue_create(SKLogger.Constants.logQueueIdentifier, nil)
         }
 
         return Statics.logQueue
     }
 
     private var _dateFormatter: NSDateFormatter? = nil
-    public var dateFormatter: NSDateFormatter? {
+    var dateFormatter: NSDateFormatter? {
         get {
             if _dateFormatter != nil {
                 return _dateFormatter
@@ -229,24 +230,23 @@ public class XCGLogger: CustomDebugStringConvertible {
         }
     }
 
-    public lazy var logDestination: XCGConsoleLogDestination =
-        XCGConsoleLogDestination(owner: self)
+    lazy var logDestination: SKConsoleLogDestination = SKConsoleLogDestination(owner: self)
 
     // MARK: - Default instance
-    public class func defaultInstance() -> XCGLogger {
+    class func defaultInstance() -> SKLogger {
         struct Statics {
-            static let instance: XCGLogger = XCGLogger()
+            static let instance: SKLogger = SKLogger()
         }
 
         return Statics.instance
     }
 
     // MARK: - Setup methods
-    public class func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
+    class func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
         defaultInstance().setup(logLevel, showLogIdentifier: showLogIdentifier, showFunctionName: showFunctionName, showThreadName: showThreadName, showLogLevel: showLogLevel, showFileNames: showFileNames, showLineNumbers: showLineNumbers, showDate: showDate)
     }
 
-    public func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
+    func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
         outputLogLevel = logLevel;
 
         logDestination.showFunctionName = showFunctionName
@@ -259,20 +259,20 @@ public class XCGLogger: CustomDebugStringConvertible {
     }
 
     // MARK: - Logging methods
-    public class func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public class func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, closure: () -> String?) {
+    class func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, closure: () -> String?) {
         self.defaultInstance().logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    public func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, @noescape closure: () -> String?) {
-        var logDetails: XCGLogDetails!
+    func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, @noescape closure: () -> String?) {
+        var logDetails: SKLogDetails!
 
         guard logDestination.isEnabledForLogLevel(logLevel) else {
          return
@@ -283,18 +283,18 @@ public class XCGLogger: CustomDebugStringConvertible {
                 return
             }
 
-            logDetails = XCGLogDetails(logLevel: logLevel, date: NSDate(), logMessage: logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
+            logDetails = SKLogDetails(logLevel: logLevel, date: NSDate(), logMessage: logMessage, functionName: functionName, fileName: fileName, lineNumber: lineNumber)
         }
 
         logDestination.processLogDetails(logDetails)
 
     }
 
-    public class func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
+    class func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel, closure: closure)
     }
 
-    public func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
+    func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
         guard isEnabledForLogLevel(logLevel) else {
             return
         }
@@ -304,78 +304,78 @@ public class XCGLogger: CustomDebugStringConvertible {
 
     // MARK: - Convenience logging methods
     // MARK: * Verbose
-    public class func verbose(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func verbose(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Debug
-    public class func debug(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func debug(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Info
-    public class func info(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func info(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Warning
-    public class func warning(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func warning(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Warning, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Error
-    public class func error(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func error(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Error, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Severe
-    public class func severe(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func severe(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(.Severe, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: - Exec Methods
     // MARK: * Verbose
-    public class func verboseExec(closure: () -> () = {}) {
+    class func verboseExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Verbose, closure: closure)
     }
 
     // MARK: * Debug
-    public class func debugExec(closure: () -> () = {}) {
+    class func debugExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Debug, closure: closure)
     }
 
     // MARK: * Info
-    public class func infoExec(closure: () -> () = {}) {
+    class func infoExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Info, closure: closure)
     }
 
     // MARK: * Warning
-    public class func warningExec(closure: () -> () = {}) {
+    class func warningExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Warning, closure: closure)
     }
 
     // MARK: * Error
-    public class func errorExec(closure: () -> () = {}) {
+    class func errorExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Error, closure: closure)
     }
 
     // MARK: * Severe
-    public class func severeExec(closure: () -> () = {}) {
+    class func severeExec(closure: () -> () = {}) {
         self.defaultInstance().exec(LogLevel.Severe, closure: closure)
     }
 
     // MARK: - Misc methods
-    public func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
+    func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
         return logLevel >= self.outputLogLevel
     }
 
     // MARK: - Private methods
     private func _logln(logMessage: String, logLevel: LogLevel = .Debug) {
 
-        var logDetails: XCGLogDetails? = nil
+        var logDetails: SKLogDetails? = nil
         if (logDestination.isEnabledForLogLevel(logLevel)) {
             if logDetails == nil {
-                logDetails = XCGLogDetails(logLevel: logLevel, date: NSDate(), logMessage: logMessage, functionName: "", fileName: "", lineNumber: 0)
+                logDetails = SKLogDetails(logLevel: logLevel, date: NSDate(), logMessage: logMessage, functionName: "", fileName: "", lineNumber: 0)
             }
             
             logDestination.processInternalLogDetails(logDetails!)
@@ -384,18 +384,13 @@ public class XCGLogger: CustomDebugStringConvertible {
 
 
     // MARK: - DebugPrintable
-    public var debugDescription: String {
+    var debugDescription: String {
         get {
             var description: String = "\(extractClassName(self)): - logDestination: \r"
             description += "\t \(logDestination.debugDescription)\r"
             return description
         }
     }
-}
-
-// Implement Comparable for LogLevel
-public func < (lhs:LogLevel, rhs:LogLevel) -> Bool {
-    return lhs.rawValue < rhs.rawValue
 }
 
 func extractClassName(someObject: Any) -> String {

--- a/StyleKit/Utilities/SKLogger.swift
+++ b/StyleKit/Utilities/SKLogger.swift
@@ -12,25 +12,17 @@ import Foundation
     import UIKit
 #endif
 
-public enum LogLevel: Int, Comparable, CustomStringConvertible {
-    case Verbose
+/// Log Level
+public enum SKLogLevel: Int, Comparable, CustomStringConvertible {
     case Debug
-    case Info
-    case Warning
     case Error
     case Severe
     case None
 
     public var description: String {
         switch self {
-        case .Verbose:
-            return "Verbose"
         case .Debug:
             return "Debug"
-        case .Info:
-            return "Info"
-        case .Warning:
-            return "Warning"
         case .Error:
             return "Error"
         case .Severe:
@@ -41,8 +33,8 @@ public enum LogLevel: Int, Comparable, CustomStringConvertible {
     }
 }
 
-// Implement Comparable for LogLevel
-public func < (lhs:LogLevel, rhs:LogLevel) -> Bool {
+// Implement Comparable for SKLogLevel
+public func < (lhs:SKLogLevel, rhs:SKLogLevel) -> Bool {
     return lhs.rawValue < rhs.rawValue
 }
 
@@ -50,14 +42,14 @@ public func < (lhs:LogLevel, rhs:LogLevel) -> Bool {
 // MARK: - SKLogDetails
 // - Data structure to hold all info about a log message, passed to log destination classes
 internal struct SKLogDetails {
-    var logLevel: LogLevel
+    var logLevel: SKLogLevel
     var date: NSDate
     var logMessage: String
     var functionName: String
     var fileName: String
     var lineNumber: Int
 
-    init(logLevel: LogLevel, date: NSDate, logMessage: String, functionName: StaticString, fileName: StaticString, lineNumber: Int) {
+    init(logLevel: SKLogLevel, date: NSDate, logMessage: String, functionName: StaticString, fileName: StaticString, lineNumber: Int) {
         self.logLevel = logLevel
         self.date = date
         self.logMessage = logMessage
@@ -72,13 +64,13 @@ internal struct SKLogDetails {
 internal class SKConsoleLogDestination: CustomDebugStringConvertible {
     // MARK: - Properties
     var owner: SKLogger
-    var outputLogLevel: LogLevel = .Debug
+    var outputSKLogLevel: SKLogLevel = .Debug
 
     var showFunctionName: Bool = true
     var showThreadName: Bool = false
     var showFileName: Bool = true
     var showLineNumber: Bool = true
-    var showLogLevel: Bool = true
+    var showSKLogLevel: Bool = true
     var showDate: Bool = true
 
     var logQueue: dispatch_queue_t? = nil
@@ -86,7 +78,7 @@ internal class SKConsoleLogDestination: CustomDebugStringConvertible {
     // MARK: - CustomDebugStringConvertible
     var debugDescription: String {
         get {
-            return "\(extractClassName(self)): - LogLevel: \(outputLogLevel) showFunctionName: \(showFunctionName) showThreadName: \(showThreadName) showLogLevel: \(showLogLevel) showFileName: \(showFileName) showLineNumber: \(showLineNumber) showDate: \(showDate)"
+            return "\(extractClassName(self)): - SKLogLevel: \(outputSKLogLevel) showFunctionName: \(showFunctionName) showThreadName: \(showThreadName) showSKLogLevel: \(showSKLogLevel) showFileName: \(showFileName) showLineNumber: \(showLineNumber) showDate: \(showDate)"
         }
     }
 
@@ -109,7 +101,7 @@ internal class SKConsoleLogDestination: CustomDebugStringConvertible {
             extendedDetails += formattedDate + " "
         }
 
-        if showLogLevel {
+        if showSKLogLevel {
             extendedDetails += "[\(logDetails.logLevel)] "
         }
 
@@ -159,7 +151,7 @@ internal class SKConsoleLogDestination: CustomDebugStringConvertible {
             extendedDetails += formattedDate + " "
         }
 
-        if showLogLevel {
+        if showSKLogLevel {
             extendedDetails += "[\(logDetails.logLevel)] "
         }
 
@@ -168,8 +160,8 @@ internal class SKConsoleLogDestination: CustomDebugStringConvertible {
     }
 
     // MARK: - Misc methods
-    func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
-        return logLevel >= self.outputLogLevel
+    func isEnabledForSKLogLevel (logLevel: SKLogLevel) -> Bool {
+        return logLevel >= self.outputSKLogLevel
     }
 
     // MARK: - Output
@@ -196,9 +188,9 @@ internal class SKLogger: CustomDebugStringConvertible {
     }
 
     // MARK: - Properties (Options)
-    var outputLogLevel: LogLevel = .Debug {
+    var outputSKLogLevel: SKLogLevel = .Debug {
         didSet {
-            logDestination.outputLogLevel = outputLogLevel
+            logDestination.outputSKLogLevel = outputSKLogLevel
         }
     }
 
@@ -242,40 +234,40 @@ internal class SKLogger: CustomDebugStringConvertible {
     }
 
     // MARK: - Setup methods
-    class func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
-        defaultInstance().setup(logLevel, showLogIdentifier: showLogIdentifier, showFunctionName: showFunctionName, showThreadName: showThreadName, showLogLevel: showLogLevel, showFileNames: showFileNames, showLineNumbers: showLineNumbers, showDate: showDate)
+    class func setup(logLevel: SKLogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showSKLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
+        defaultInstance().setup(logLevel, showLogIdentifier: showLogIdentifier, showFunctionName: showFunctionName, showThreadName: showThreadName, showSKLogLevel: showSKLogLevel, showFileNames: showFileNames, showLineNumbers: showLineNumbers, showDate: showDate)
     }
 
-    func setup(logLevel: LogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
-        outputLogLevel = logLevel;
+    func setup(logLevel: SKLogLevel = .Debug, showLogIdentifier: Bool = false, showFunctionName: Bool = true, showThreadName: Bool = false, showSKLogLevel: Bool = true, showFileNames: Bool = true, showLineNumbers: Bool = true, showDate: Bool = true) {
+        outputSKLogLevel = logLevel;
 
         logDestination.showFunctionName = showFunctionName
         logDestination.showThreadName = showThreadName
-        logDestination.showLogLevel = showLogLevel
+        logDestination.showSKLogLevel = showSKLogLevel
         logDestination.showFileName = showFileNames
         logDestination.showLineNumber = showLineNumbers
         logDestination.showDate = showDate
-        logDestination.outputLogLevel = logLevel
+        logDestination.outputSKLogLevel = logLevel
     }
 
     // MARK: - Logging methods
-    class func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    class func logln(@autoclosure(escaping) closure: () -> String?, logLevel: SKLogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.defaultInstance().logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    class func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, closure: () -> String?) {
+    class func logln(logLevel: SKLogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, closure: () -> String?) {
         self.defaultInstance().logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    func logln(@autoclosure(escaping) closure: () -> String?, logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
+    func logln(@autoclosure(escaping) closure: () -> String?, logLevel: SKLogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
         self.logln(logLevel, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    func logln(logLevel: LogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, @noescape closure: () -> String?) {
+    func logln(logLevel: SKLogLevel = .Debug, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line, @noescape closure: () -> String?) {
         var logDetails: SKLogDetails!
 
-        guard logDestination.isEnabledForLogLevel(logLevel) else {
-         return
+        guard logDestination.isEnabledForSKLogLevel(logLevel) else {
+            return
         }
 
         if logDetails == nil {
@@ -290,22 +282,15 @@ internal class SKLogger: CustomDebugStringConvertible {
 
     }
 
-    class func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
+    class func exec(logLevel: SKLogLevel = .Debug, closure: () -> () = {}) {
         self.defaultInstance().exec(logLevel, closure: closure)
     }
 
-    func exec(logLevel: LogLevel = .Debug, closure: () -> () = {}) {
-        guard isEnabledForLogLevel(logLevel) else {
+    func exec(logLevel: SKLogLevel = .Debug, closure: () -> () = {}) {
+        guard isEnabledForSKLogLevel(logLevel) else {
             return
         }
         closure()
-    }
-
-
-    // MARK: - Convenience logging methods
-    // MARK: * Verbose
-    class func verbose(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
-        self.defaultInstance().logln(.Verbose, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
     // MARK: * Debug
@@ -313,15 +298,6 @@ internal class SKLogger: CustomDebugStringConvertible {
         self.defaultInstance().logln(.Debug, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    // MARK: * Info
-    class func info(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
-        self.defaultInstance().logln(.Info, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
-    }
-
-    // MARK: * Warning
-    class func warning(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
-        self.defaultInstance().logln(.Warning, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
-    }
 
     // MARK: * Error
     class func error(@autoclosure(escaping) closure: () -> String?, functionName: StaticString = #function, fileName: StaticString = #file, lineNumber: Int = #line) {
@@ -333,51 +309,35 @@ internal class SKLogger: CustomDebugStringConvertible {
         self.defaultInstance().logln(.Severe, functionName: functionName, fileName: fileName, lineNumber: lineNumber, closure: closure)
     }
 
-    // MARK: - Exec Methods
-    // MARK: * Verbose
-    class func verboseExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Verbose, closure: closure)
-    }
-
     // MARK: * Debug
     class func debugExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Debug, closure: closure)
-    }
-
-    // MARK: * Info
-    class func infoExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Info, closure: closure)
-    }
-
-    // MARK: * Warning
-    class func warningExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Warning, closure: closure)
+        self.defaultInstance().exec(SKLogLevel.Debug, closure: closure)
     }
 
     // MARK: * Error
     class func errorExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Error, closure: closure)
+        self.defaultInstance().exec(SKLogLevel.Error, closure: closure)
     }
 
     // MARK: * Severe
     class func severeExec(closure: () -> () = {}) {
-        self.defaultInstance().exec(LogLevel.Severe, closure: closure)
+        self.defaultInstance().exec(SKLogLevel.Severe, closure: closure)
     }
 
     // MARK: - Misc methods
-    func isEnabledForLogLevel (logLevel: LogLevel) -> Bool {
-        return logLevel >= self.outputLogLevel
+    func isEnabledForSKLogLevel (logLevel: SKLogLevel) -> Bool {
+        return logLevel >= self.outputSKLogLevel
     }
 
     // MARK: - Private methods
-    private func _logln(logMessage: String, logLevel: LogLevel = .Debug) {
+    private func _logln(logMessage: String, logLevel: SKLogLevel = .Debug) {
 
         var logDetails: SKLogDetails? = nil
-        if (logDestination.isEnabledForLogLevel(logLevel)) {
+        if (logDestination.isEnabledForSKLogLevel(logLevel)) {
             if logDetails == nil {
                 logDetails = SKLogDetails(logLevel: logLevel, date: NSDate(), logMessage: logMessage, functionName: "", fileName: "", lineNumber: 0)
             }
-            
+
             logDestination.processInternalLogDetails(logDetails!)
         }
     }


### PR DESCRIPTION
Renames XCGLogDetails to SKLogDetails
Renames XCGConsoleLogDestination to SKConsoleLogDestination
Renames XCGLogger to SKLogger

Corrects access level of Logging classes to internal
