### PR TITLE
Added catch for individual keys in the json being malformed.

### DIFF
--- a/StyleKit/Stylist.swift
+++ b/StyleKit/Stylist.swift
@@ -37,12 +37,15 @@ class Stylist {
                 }
             }
             else {
-                if let currentComponent = self.currentComponent {
-                    applyStyle(key, object: value, currentComponent: currentComponent)
-                } else {
-                    SKLogger.error("Style \(value) not applied on \(key) for \(self.currentComponent.debugDescription)")
-                }
-                
+                SKTryCatch.tryBlock( {
+                    if let currentComponent = self.currentComponent {
+                        self.applyStyle(key, object: value, currentComponent: currentComponent)
+                    } else {
+                        SKLogger.error("Style \(value) not applied on \(key) for \(self.currentComponent.debugDescription)")
+                    }
+                }, catchBlock: { exception in
+                    SKLogger.error("Style \(value) not applied on \(key) for \(self.currentComponent.debugDescription) Error \(exception)")
+                }, finallyBlock: nil)
             }
         }
     }


### PR DESCRIPTION
StyleKit 0.4.1 there is only one try/catch at the global apply level so if any of the selectors are bad, parsing will stop.  This leaves the entire application styling susceptible to styling failure if an iOS update changes or removes a UIAppearance protocol key.   With this update there is a try/catch for each selector so if a failure happens you will only lose that key.

To Test: Add a bad key for UITextField in the StyleKit demo project (by changing "font" to "fontA").  Style kit 0.4.1 you will lose styling on all demo elements.  Now, only that element will not style.
