### PR TITLE
Feature/add style previewer(#28)

### DIFF
--- a/StyleKitDemo/StyleKitDemo.xcodeproj/project.pbxproj
+++ b/StyleKitDemo/StyleKitDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A104CE1E1D57E23C00626F2A /* SKLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104CE1D1D57E23C00626F2A /* SKLabel.swift */; };
 		A104CE201D57E25E00626F2A /* SKTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104CE1F1D57E25E00626F2A /* SKTextField.swift */; };
 		A104CE411D57FEDB00626F2A /* SKNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A104CE401D57FEDB00626F2A /* SKNavigationBar.swift */; };
+		A1A7FDD61D780EDC00D42F87 /* StylePreviewerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A7FDD51D780EDC00D42F87 /* StylePreviewerViewController.swift */; };
 		A1C515681D5A72CF0016BF1E /* StyleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C515671D5A72CF0016BF1E /* StyleParser.swift */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +53,7 @@
 		A104CE1D1D57E23C00626F2A /* SKLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SKLabel.swift; path = CustomViews/SKLabel.swift; sourceTree = "<group>"; };
 		A104CE1F1D57E25E00626F2A /* SKTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SKTextField.swift; path = CustomViews/SKTextField.swift; sourceTree = "<group>"; };
 		A104CE401D57FEDB00626F2A /* SKNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SKNavigationBar.swift; path = CustomViews/SKNavigationBar.swift; sourceTree = "<group>"; };
+		A1A7FDD51D780EDC00D42F87 /* StylePreviewerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StylePreviewerViewController.swift; sourceTree = "<group>"; };
 		A1C515671D5A72CF0016BF1E /* StyleParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StyleParser.swift; path = Style/StyleParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -92,6 +94,7 @@
 				A104CE031D57DCD500626F2A /* AppDelegate.swift */,
 				A104CE051D57DCD500626F2A /* ViewController.swift */,
 				A104CE071D57DCD500626F2A /* Main.storyboard */,
+				A1A7FDD51D780EDC00D42F87 /* StylePreviewerViewController.swift */,
 				A104CE0A1D57DCD500626F2A /* Assets.xcassets */,
 				A104CE0C1D57DCD500626F2A /* LaunchScreen.storyboard */,
 				A104CE0F1D57DCD500626F2A /* Info.plist */,
@@ -209,6 +212,7 @@
 				A104CE1E1D57E23C00626F2A /* SKLabel.swift in Sources */,
 				A104CE1C1D57E22000626F2A /* SKButton.swift in Sources */,
 				A104CE201D57E25E00626F2A /* SKTextField.swift in Sources */,
+				A1A7FDD61D780EDC00D42F87 /* StylePreviewerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StyleKitDemo/StyleKitDemo.xcodeproj/project.pbxproj
+++ b/StyleKitDemo/StyleKitDemo.xcodeproj/project.pbxproj
@@ -90,11 +90,10 @@
 			isa = PBXGroup;
 			children = (
 				A104CE181D57E1AB00626F2A /* CustomViews */,
+				A1A7FDD71D7815B900D42F87 /* Views */,
 				A104CE151D57DD0600626F2A /* Style */,
 				A104CE031D57DCD500626F2A /* AppDelegate.swift */,
-				A104CE051D57DCD500626F2A /* ViewController.swift */,
 				A104CE071D57DCD500626F2A /* Main.storyboard */,
-				A1A7FDD51D780EDC00D42F87 /* StylePreviewerViewController.swift */,
 				A104CE0A1D57DCD500626F2A /* Assets.xcassets */,
 				A104CE0C1D57DCD500626F2A /* LaunchScreen.storyboard */,
 				A104CE0F1D57DCD500626F2A /* Info.plist */,
@@ -129,6 +128,15 @@
 				059932E71D5B244C0085E522 /* StyleKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A1A7FDD71D7815B900D42F87 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A104CE051D57DCD500626F2A /* ViewController.swift */,
+				A1A7FDD51D780EDC00D42F87 /* StylePreviewerViewController.swift */,
+			);
+			name = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/StyleKitDemo/StyleKitDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/StyleKitDemo/StyleKitDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/StyleKitDemo/StyleKitDemo/Base.lproj/Main.storyboard
+++ b/StyleKitDemo/StyleKitDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="RxZ-s5-nJd">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="RxZ-s5-nJd">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>
         <!--StyleKit Demo-->
@@ -21,13 +22,13 @@
                                         <rect key="frame" x="0.0" y="64" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BxD-hU-8O9" id="tWB-NC-aa8">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Buttons" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eP1-oS-KNS">
                                                     <rect key="frame" x="14" y="11" width="60" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -40,13 +41,13 @@
                                         <rect key="frame" x="0.0" y="108" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tNu-JG-74N" id="Rrd-Rt-BQ7">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Labels" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y15-q0-bLz">
                                                     <rect key="frame" x="14" y="11" width="51" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -59,13 +60,13 @@
                                         <rect key="frame" x="0.0" y="152" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uu2-xZ-9UN" id="zXe-HA-Re4">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Nesting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ld-Mg-dAt">
                                                     <rect key="frame" x="14" y="11" width="60" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -78,19 +79,38 @@
                                         <rect key="frame" x="0.0" y="196" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AEc-L0-OEU" id="QU7-Ub-DmY">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Other" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fim-RH-Rkv">
                                                     <rect key="frame" x="14" y="11" width="44" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="FYY-GK-dO4" kind="show" id="Jri-60-TbA"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KRD-Kn-syx">
+                                        <rect key="frame" x="0.0" y="240" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KRD-Kn-syx" id="cFU-5D-kad">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Style Previewer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="774-Ja-MFn">
+                                                    <rect key="frame" x="14" y="11" width="191" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="PbG-b7-4Ev" kind="show" action="showDetailViewController:sender:" id="wXZ-Ms-gFs"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -164,7 +184,7 @@
                                     <constraint firstAttribute="height" constant="30" id="ldd-KU-onV"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UILabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rgr-UU-a38">
@@ -174,7 +194,7 @@
                                     <constraint firstAttribute="height" constant="30" id="fdD-DL-1jE"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -190,6 +210,89 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GkV-bG-bnN" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2360" y="-22"/>
+        </scene>
+        <!--Style Previewer-->
+        <scene sceneID="gFB-M4-aY2">
+            <objects>
+                <viewController id="PbG-b7-4Ev" userLabel="Style Previewer" customClass="StylePreviewerViewController" customModule="StyleKitDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="YOB-mH-ac3"/>
+                        <viewControllerLayoutGuide type="bottom" id="OWO-Nd-ebQ"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="1WY-Hf-31t">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZHZ-GB-UoA">
+                                <rect key="frame" x="0.0" y="390" width="600" height="210"/>
+                            </pickerView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="kwc-Uy-40q">
+                                <rect key="frame" x="0.0" y="64" width="600" height="326"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select from below to preview the style on your device" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hFt-2H-i0M">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="65"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="sHf-T8-8Ch">
+                                        <rect key="frame" x="0.0" y="65" width="600" height="95"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Font:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vZK-G0-1gP">
+                                                <rect key="frame" x="0.0" y="0.0" width="300" height="95"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Font" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="h2z-te-8Gx">
+                                                <rect key="frame" x="300" y="0.0" width="300" height="95"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="atf_selectedFontTextField:" destination="PbG-b7-4Ev" eventType="touchUpInside" id="tK5-do-79P"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Preview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNV-yh-Qzf">
+                                        <rect key="frame" x="0.0" y="160" width="600" height="103"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Stylish Brown Fox" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r0E-Dx-Fa7">
+                                        <rect key="frame" x="0.0" y="262" width="600" height="64"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="hFt-2H-i0M" firstAttribute="height" secondItem="kwc-Uy-40q" secondAttribute="height" multiplier="0.2" id="p0e-lL-VPF"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="kwc-Uy-40q" firstAttribute="top" secondItem="YOB-mH-ac3" secondAttribute="bottom" id="AqO-NC-lcR"/>
+                            <constraint firstItem="kwc-Uy-40q" firstAttribute="centerX" secondItem="1WY-Hf-31t" secondAttribute="centerX" id="IAf-5W-w9h"/>
+                            <constraint firstItem="ZHZ-GB-UoA" firstAttribute="height" secondItem="1WY-Hf-31t" secondAttribute="height" multiplier="0.35" id="LFv-Lm-1En"/>
+                            <constraint firstItem="ZHZ-GB-UoA" firstAttribute="top" secondItem="kwc-Uy-40q" secondAttribute="bottom" id="bDw-eZ-Cdo"/>
+                            <constraint firstItem="OWO-Nd-ebQ" firstAttribute="top" secondItem="ZHZ-GB-UoA" secondAttribute="bottom" id="dZh-Pe-6An"/>
+                            <constraint firstItem="ZHZ-GB-UoA" firstAttribute="width" secondItem="1WY-Hf-31t" secondAttribute="width" id="j5k-f2-KrJ"/>
+                            <constraint firstItem="kwc-Uy-40q" firstAttribute="width" secondItem="1WY-Hf-31t" secondAttribute="width" id="q5O-sk-IDS"/>
+                            <constraint firstItem="ZHZ-GB-UoA" firstAttribute="centerX" secondItem="1WY-Hf-31t" secondAttribute="centerX" id="uCl-Ya-eGn"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="lbl_textPreview" destination="r0E-Dx-Fa7" id="CiL-AG-z7s"/>
+                        <outlet property="picker_FontSelector" destination="ZHZ-GB-UoA" id="U2E-MF-t51"/>
+                        <outlet property="tf_SelectFont" destination="h2z-te-8Gx" id="fjp-B3-XLp"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="EbO-Tu-r46" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2360" y="2025"/>
         </scene>
         <!--Nesting-->
         <scene sceneID="XuI-ac-mDa">
@@ -215,7 +318,7 @@
                                                     <constraint firstAttribute="width" constant="208" id="IQA-e1-z8t"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
@@ -229,7 +332,7 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Inside Scroll View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hvs-1e-emS">
                                         <rect key="frame" x="53" y="13" width="134" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -252,7 +355,7 @@
                                     <constraint firstAttribute="width" constant="240" id="hhQ-Fl-bGg"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>

--- a/StyleKitDemo/StyleKitDemo/Base.lproj/Main.storyboard
+++ b/StyleKitDemo/StyleKitDemo/Base.lproj/Main.storyboard
@@ -225,6 +225,10 @@
                         <subviews>
                             <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZHZ-GB-UoA">
                                 <rect key="frame" x="0.0" y="390" width="600" height="210"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="PbG-b7-4Ev" id="bpZ-nB-3gf"/>
+                                    <outlet property="delegate" destination="PbG-b7-4Ev" id="PID-FS-WYi"/>
+                                </connections>
                             </pickerView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="kwc-Uy-40q">
                                 <rect key="frame" x="0.0" y="64" width="600" height="326"/>
@@ -236,32 +240,39 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="sHf-T8-8Ch">
-                                        <rect key="frame" x="0.0" y="65" width="600" height="95"/>
+                                        <rect key="frame" x="0.0" y="65" width="600" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Font:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vZK-G0-1gP">
-                                                <rect key="frame" x="0.0" y="0.0" width="300" height="95"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Font Name:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vZK-G0-1gP">
+                                                <rect key="frame" x="0.0" y="0.0" width="300" height="50"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="MfD-4W-4wS"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Font" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="h2z-te-8Gx">
-                                                <rect key="frame" x="300" y="0.0" width="300" height="95"/>
+                                                <rect key="frame" x="300" y="0.0" width="300" height="50"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="SvO-wl-8wR"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
+                                                    <action selector="atf_selectedFontTextField:" destination="PbG-b7-4Ev" eventType="touchDown" id="388-WN-Edi"/>
                                                     <action selector="atf_selectedFontTextField:" destination="PbG-b7-4Ev" eventType="touchUpInside" id="tK5-do-79P"/>
                                                 </connections>
                                             </textField>
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Preview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNV-yh-Qzf">
-                                        <rect key="frame" x="0.0" y="160" width="600" height="103"/>
+                                        <rect key="frame" x="0.0" y="115" width="600" height="86"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Stylish Brown Fox" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r0E-Dx-Fa7">
-                                        <rect key="frame" x="0.0" y="262" width="600" height="64"/>
+                                        <rect key="frame" x="0.0" y="201" width="600" height="125"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>

--- a/StyleKitDemo/StyleKitDemo/Style/style.json
+++ b/StyleKitDemo/StyleKitDemo/Style/style.json
@@ -9,7 +9,7 @@
     "UITableView": {
         "UITableViewCell": {
             "UILabel": {
-                "font": "HelveticaNeue-Medium:13.0",
+                "font": "HelveticaNeue-Medium:15.0",
                 "color": "#000"
             }
         }
@@ -37,10 +37,6 @@
         "font": "HelveticaNeue-Light:17.0",
         "color": "#cd0073"
     },
-    "UILabel": {
-        "font": "HelveticaNeue-Bold:15.0",
-        "color": "#8000c6"
-    },
     "UIScrollView": {
         "UILabel": {
             "font": "HelveticaNeue-Light:15.0",
@@ -53,14 +49,6 @@
                 "padding": [0,30,0,0],
                 "backgroundColor": "#eee"
             }
-        }
-    },
-    "UITextField": {
-        "font": "HelveticaNeue-Light:15.0",
-        "textColor": "#000",
-        "UILabel": {
-            "font": "HelveticaNeue-Medium:15.0",
-            "color": "#000"
         }
     },
     "StyleKitDemo.SKTextField": {

--- a/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
+++ b/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
@@ -1,0 +1,43 @@
+//
+//  StylePreviewerViewController.swift
+//  StyleKitDemo
+//
+//  Created by Grant Kemp on 01/09/2016.
+//  Copyright © 2016 Bernard Gatt. All rights reserved.
+//
+
+import UIKit
+
+class StylePreviewerViewController: UIViewController {
+
+    @IBOutlet weak var tf_SelectFont: UITextField!
+    
+    @IBOutlet weak var picker_FontSelector: UIPickerView!
+    
+    @IBOutlet weak var lbl_textPreview: UILabel!
+    
+    //MARK: UI Actions
+    
+    @IBAction func atf_selectedFontTextField(sender: UITextField) {
+        
+    }
+    
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        
+    }
+    
+    //MARK: Methods
+    
+    func _StartSelectingFont() {
+        
+    }
+    
+    func _DidSelectFontfromPicker() {
+        
+    }
+    
+}

--- a/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
+++ b/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
@@ -39,7 +39,6 @@ class StylePreviewerViewController: UIViewController, UIPickerViewDataSource, UI
     }
     
     func _DidSelectFontfromPicker(fontfamilyname:String) {
-        let selectedFont = picker_FontSelector.selectedRowInComponent(0)
         lbl_textPreview.font = UIFont(name: fontfamilyname, size: 18)
         lbl_textPreview.hidden = false
         tf_SelectFont.text = fontfamilyname

--- a/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
+++ b/StyleKitDemo/StyleKitDemo/StylePreviewerViewController.swift
@@ -8,8 +8,10 @@
 
 import UIKit
 
-class StylePreviewerViewController: UIViewController {
+class StylePreviewerViewController: UIViewController, UIPickerViewDataSource, UIPickerViewDelegate {
 
+    var picker_Data = [String]()
+    
     @IBOutlet weak var tf_SelectFont: UITextField!
     
     @IBOutlet weak var picker_FontSelector: UIPickerView!
@@ -19,25 +21,61 @@ class StylePreviewerViewController: UIViewController {
     //MARK: UI Actions
     
     @IBAction func atf_selectedFontTextField(sender: UITextField) {
-        
+        _StartSelectingFont()
     }
     
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        setupView()
         
     }
     
     //MARK: Methods
     
     func _StartSelectingFont() {
-        
+        picker_FontSelector.hidden = false
     }
     
-    func _DidSelectFontfromPicker() {
+    func _DidSelectFontfromPicker(fontfamilyname:String) {
+        let selectedFont = picker_FontSelector.selectedRowInComponent(0)
+        lbl_textPreview.font = UIFont(name: fontfamilyname, size: 18)
+        lbl_textPreview.hidden = false
+        tf_SelectFont.text = fontfamilyname
+    }
+    
+    
+    //MARK: View Setup
+    func setupView() {
+        picker_FontSelector.hidden = true
+        tf_SelectFont.placeholder = "Select Font"
+        lbl_textPreview.hidden = true
+        picker_Data = generateFonts()
+    }
+    
+    //MARK: Picker Delegate
+    func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return picker_Data.count
+     
+    }
+    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return picker_Data[row]
+    }
+    
+    //MARK: Helpers
+    //TODO: Move this to seperate Utility Class
+    func generateFonts() -> [String] {
+       return  UIFont.familyNames()
         
+    }
+    func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let fontSelected = picker_Data[row]
+        _DidSelectFontfromPicker(fontSelected)
     }
     
 }

--- a/StyleKitDemo/StyleKitDemo/ViewController.swift
+++ b/StyleKitDemo/StyleKitDemo/ViewController.swift
@@ -6,9 +6,6 @@ class ViewController: UIViewController {
         super.viewDidLoad()
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
 
 
 }


### PR DESCRIPTION
Added a simple Style Previewer which can be used in the new IOS 10 to preview the design and then copy it to the desktop via cross device pasteboard. 

This should speed up the workflow drastically, ideally in the future the app could also auto-generate the json for the style.
