### PR TITLE
Remove logQueue unwrap forcing

### DIFF
--- a/StyleKit/Utilities/SKLogger.swift
+++ b/StyleKit/Utilities/SKLogger.swift
@@ -114,7 +114,7 @@ internal class SKConsoleLogDestination: CustomDebugStringConvertible {
                 if let threadName = Thread.current.name , !threadName.isEmpty {
                     extendedDetails += "[" + threadName + "] "
                 }
-                else if let queueName = String(validatingUTF8: logQueue!.label) , !queueName.isEmpty {
+                else if let label = logQueue?.label, let queueName = String(validatingUTF8: label) , !queueName.isEmpty {
                     extendedDetails += "[" + queueName + "] "
                 }
                 else {


### PR DESCRIPTION
Application could crash if calling `apply()` in background queue

I try to do some live reloading  and have crash if I use some other dispatch queue

Here my code in your demo app delegate without file monitoring, just a scheduled style reload
(monitoring could done with dispatch source, I use swift framework FileKit or KZFileWatchers
or http://johnholdsworth.com/injection.html)
```swift
 if Platform.isSimulator {
      var curFile = URL(fileURLWithPath: #file)
      curFile.deleteLastPathComponent()
     curFile.appendPathComponent("Style/style.json")
                
     DispatchQueue.main.after(20) { // see alamofire for extension
         let styleKit = StyleKit(fileUrl: curFile, logLevel: .debug)
         styleKit?.apply()
    }
}
```